### PR TITLE
修复V20 alpha1 插件加载失败问题

### DIFF
--- a/resources/lib/sub_provider_service.py
+++ b/resources/lib/sub_provider_service.py
@@ -38,10 +38,10 @@ __scriptname__ = __addon__.getAddonInfo('name')
 __version__ = __addon__.getAddonInfo('version')
 __language__ = __addon__.getLocalizedString
 
-__cwd__ = xbmc.translatePath(__addon__.getAddonInfo('path'))
-__profile__ = xbmc.translatePath(__addon__.getAddonInfo('profile'))
-__resource__ = xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib'))
-__temp__ = xbmc.translatePath(os.path.join(__profile__, 'temp'))
+__cwd__ = xbmcvfs.translatePath(__addon__.getAddonInfo('path'))
+__profile__ = xbmcvfs.translatePath(__addon__.getAddonInfo('profile'))
+__resource__ = xbmcvfs.translatePath(os.path.join(__cwd__, 'resources', 'lib'))
+__temp__ = xbmcvfs.translatePath(os.path.join(__profile__, 'temp'))
 
 sys.path.append(__resource__)
 


### PR DESCRIPTION
```
                         Error Type: <class 'AttributeError'>
                                                   Error Contents: module 'kodi_six.xbmc' has no attribute 'translatePath'
                                                   Traceback (most recent call last):
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/script.subtitles.zimukux/resources/lib/addon_entry.py", line 1, in <module>
                                                       import sub_provider_service
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/script.subtitles.zimukux/resources/lib/sub_provider_service.py", line 42, in <module>
                                                       __temp__ = xbmc.translatePath(os.path.join(__profile__, 'temp'))
                                                   AttributeError: module 'kodi_six.xbmc' has no attribute 'translatePath'
```

参照https://github.com/CastagnaIT/plugin.video.netflix/issues/1145