### PR TITLE
大写扩展名支持和UI调整

### DIFF
--- a/resources/language/resource.language.en_GB/strings.po
+++ b/resources/language/resource.language.en_GB/strings.po
@@ -1,0 +1,54 @@
+msgid ""
+msgstr ""
+
+msgctxt "#30100"
+msgid "Site Config for ZiMuKu"
+msgstr ""
+
+msgctxt "#30101"
+msgid "Site URL"
+msgstr ""
+
+msgctxt "#30200"
+msgid "Sub Preference"
+msgstr ""
+
+msgctxt "#30210"
+msgid "Preferred Sub Type"
+msgstr ""
+
+msgctxt "#30211"
+msgid "No Preference"
+msgstr ""
+
+msgctxt "#30212"
+msgid "ASS - colorful with various fonts"
+msgstr ""
+
+msgctxt "#30213"
+msgid "SRT - text only"
+msgstr ""
+
+msgctxt "#30220"
+msgid "Preferred Sub Language"
+msgstr ""
+
+msgctxt "#30221"
+msgid "No Preference"
+msgstr ""
+
+msgctxt "#30222"
+msgid "Simplified Chinese"
+msgstr ""
+
+msgctxt "#30223"
+msgid "Traditional Chinese"
+msgstr ""
+
+msgctxt "#30224"
+msgid "Eng + Chs"
+msgstr ""
+
+msgctxt "#30225"
+msgid "Eng + Cht"
+msgstr ""

--- a/resources/language/resource.language.en_GB/strings.po
+++ b/resources/language/resource.language.en_GB/strings.po
@@ -52,3 +52,19 @@ msgstr ""
 msgctxt "#30225"
 msgid "Eng + Cht"
 msgstr ""
+
+msgctxt "#30300"
+msgid "Proxy Settings"
+msgstr ""
+
+msgctxt "#30310"
+msgid "Follow kodi proxy settings"
+msgstr ""
+
+msgctxt "#30311"
+msgid "Use proxy"
+msgstr ""
+
+msgctxt "#30312"
+msgid "Proxy server"
+msgstr ""

--- a/resources/language/resource.language.zh_CN/strings.po
+++ b/resources/language/resource.language.zh_CN/strings.po
@@ -1,0 +1,57 @@
+msgid ""
+msgstr ""
+
+msgctxt "#30100"
+msgid "Site Config for ZiMuKu"
+msgstr "「字幕库」网站配置"
+
+msgctxt "#30101"
+msgid "Site URL"
+msgstr "网址"
+
+msgctxt "#30200"
+msgid "Sub Preference"
+msgstr "字幕下载偏好"
+
+msgctxt "#30210"
+msgid "Preferred Sub Type"
+msgstr "优先选择的字幕类型"
+
+msgctxt "#30211"
+msgid "No Preference"
+msgstr "无偏好"
+
+msgctxt "#30212"
+msgid "ASS - colorful kind with various fonts"
+msgstr "ASS - 花里胡哨那种带字体的"
+
+msgctxt "#30213"
+msgid "SRT - text only"
+msgstr "SRT - 纯文本那种"
+
+msgctxt "#30220"
+msgid "Preferred Sub Language"
+msgstr "优先选择的字幕语言"
+
+msgctxt "#30221"
+msgid "No Preference"
+msgstr "无偏好"
+
+msgctxt "#30222"
+msgid "Simplified Chinese"
+msgstr "简体中文"
+
+msgctxt "#30223"
+msgid "Traditional Chinese"
+msgstr "繁体中文"
+
+msgctxt "#30224"
+msgid "Eng + Chs"
+msgstr "双语（简）"
+
+msgctxt "#30225"
+msgid "Eng + Cht"
+msgstr "双语（繁）"
+
+
+

--- a/resources/language/resource.language.zh_CN/strings.po
+++ b/resources/language/resource.language.zh_CN/strings.po
@@ -53,5 +53,18 @@ msgctxt "#30225"
 msgid "Eng + Cht"
 msgstr "双语（繁）"
 
+msgctxt "#30300"
+msgid "Proxy Settings"
+msgstr "代理设置"
 
+msgctxt "#30310"
+msgid "Follow kodi proxy"
+msgstr "跟随Kodi代理设置"
 
+msgctxt "#30311"
+msgid "Use Proxy"
+msgstr "使用代理"
+
+msgctxt "#30312"
+msgid "Proxy server"
+msgstr "代理服务器"

--- a/resources/lib/sub_provider_service.py
+++ b/resources/lib/sub_provider_service.py
@@ -68,6 +68,16 @@ def Search(item):
 
     subtitle_list = agent.search(search_str, item)
 
+    # 粗略过滤当前集数的字幕
+    try:
+        episode = int(item['episode'])
+        es = 'E%02d' % episode
+        filtered = [s for s in subtitle_list if es in s['filename'].upper()]
+        if len(filtered) > 0:
+            subtitle_list = filtered
+    except:
+        pass
+
     if len(subtitle_list) != 0:
         for s in subtitle_list:
             listitem = xbmcgui.ListItem(label=s["language_name"], label2=s["filename"])

--- a/resources/lib/sub_provider_service.py
+++ b/resources/lib/sub_provider_service.py
@@ -221,6 +221,11 @@ def run():
     zimuku_base_url = __addon__.getSetting("ZiMuKuUrl")
     tpe = __addon__.getSetting("subtype")
     lang = __addon__.getSetting("sublang")
+    
+    if __addon__.getSetting("proxy_follow_kodi") != "true":
+        proxy = ("" if __addon__.getSetting("proxy_use") != "true"
+                    else __addon__.getSetting("proxy_server"))
+        os.environ["HTTP_PROXY"] = os.environ["HTTPS_PROXY"] = proxy
 
     agent = zmkagnt.Zimuku_Agent(zimuku_base_url, __temp__, logger, Unpacker(),
                                  {'subtype': tpe, 'sublang': lang})

--- a/resources/lib/sub_provider_service.py
+++ b/resources/lib/sub_provider_service.py
@@ -115,6 +115,15 @@ def Download(url):
     if len(sub_name_list) == 1:
         selected_sub = sub_file_list[0]
     else:
+        # 不显示相同的前缀，防止文件名过长滚动
+        base = sub_name_list[0]
+        diff_index = next(filter(
+            lambda i: any(s[i] != base[i] for s in sub_name_list),
+            range(len(base))
+        ))
+        dot = base[:diff_index].rfind('.') + 1
+        sub_name_list = [s[dot:] for s in sub_name_list]
+
         sel = xbmcgui.Dialog().select('请选择压缩包中的字幕', sub_name_list)
         if sel == -1:
             sel = 0

--- a/resources/lib/zimuku_agent.py
+++ b/resources/lib/zimuku_agent.py
@@ -470,8 +470,6 @@ class Zimuku_Agent:
             return [fn], [full_path]
         elif filename.endswith(supported_archive_exts):
             full_path = self.store_file(filename, data)
-            # libarchive requires the access to the file, so sleep a while to ensure the file.
-            time.sleep(0.5)
             archive_path, sub_name_list = self.unpacker.unpack(full_path)
 
             # 返回的文件名不能做乱码修正，不然找不到……
@@ -517,8 +515,8 @@ class Zimuku_Agent:
             ts, os.path.splitext(filename)[1])).replace('\\', '/')
         with open(tempfile, "wb") as sub_file:
             sub_file.write(data)
-            # May require close file explicitly to ensure the file.
-            sub_file.close()
+            # use fsync to ensure the file.
+            os.fsync(sub_file.fileno())
         return tempfile.replace('\\', '/')
 
     def download_links(self, links, referer):

--- a/resources/lib/zimuku_agent.py
+++ b/resources/lib/zimuku_agent.py
@@ -457,6 +457,11 @@ class Zimuku_Agent:
         if filename == '':
             # No file received.
             return [], []
+        
+        # 小写扩展名
+        dot = filename.rfind(".")
+        if dot != -1:
+            filename = filename[:dot] + filename[dot:].lower()
 
         rtn_list = []
         if filename.endswith(exts):

--- a/resources/lib/zimuku_agent.py
+++ b/resources/lib/zimuku_agent.py
@@ -515,7 +515,8 @@ class Zimuku_Agent:
             ts, os.path.splitext(filename)[1])).replace('\\', '/')
         with open(tempfile, "wb") as sub_file:
             sub_file.write(data)
-            # use fsync to ensure the file.
+            # use flush followed by fsync to ensure the file.
+            sub_file.flush()
             os.fsync(sub_file.fileno())
         return tempfile.replace('\\', '/')
 

--- a/resources/lib/zimuku_archive.py
+++ b/resources/lib/zimuku_archive.py
@@ -72,7 +72,8 @@ def unpack(file_path):
 
         subtitle_list = []
         for subfile in files:
-            if subfile.endswith(exts):
+            # 小写扩展名
+            if subfile[-4:].lower().endswith(exts):
                 subtitle_list.append(subfile)
 
     elif file_path.endswith('.7z'):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -50,5 +50,40 @@
 				</setting>
 			</group>
 		</category>
+		<category id="proxy" label="30300" help="">
+			<group id="1" label="">
+				<setting id="proxy_follow_kodi" type="boolean" label="30310" help="">
+					<level>0</level>
+					<default>true</default>
+					<control type="toggle"/>
+				</setting>
+				<setting id="proxy_use" type="boolean" label="30311" help="">
+					<level>0</level>
+					<default>true</default>
+					<control type="toggle"/>
+					<dependencies>
+						<dependency type="enable" setting="proxy_follow_kodi">false</dependency>
+					</dependencies>
+				</setting>
+                <setting id="proxy_server" type="string" label="30312" help="">
+                	<level>0</level>
+					<control type="edit" format="string">
+						<heading>30312</heading>
+					</control>
+                	<default>protocol://[user:pass@]host:port</default>
+                	<constraints>
+                		<allowempty>true</allowempty>
+                	</constraints>
+					<dependencies>
+						<dependency type="enable">
+							<and>
+								<condition setting="proxy_follow_kodi">false</condition>
+								<condition setting="proxy_use">true</condition>
+							</and>
+						</dependency>
+					</dependencies>
+                </setting>
+			</group>
+		</category>
 	</section>
 </settings>


### PR DESCRIPTION
1. 修复当压缩包或字幕扩展名为大写时提示”下载失败“的问题
2. 粗略过滤字幕搜索结果中明显不属于当前剧集的字幕
3. 移除选择压缩包中的字幕时共同的文件名前缀，避免滚动才能看到字幕语言和字幕扩展名
4. 使用flush和fsync确保文件写入，修复等待0.5s还是会偶尔出现解压错误的问题
5. 恢复语言资源文件，修复设置界面不显示文字的问题
6. 新增选项用于单独为插件配置代理服务器