### PR TITLE
ocr验证更新

### DIFF
--- a/resources/language/resource.language.zh_CN/strings.po
+++ b/resources/language/resource.language.zh_CN/strings.po
@@ -9,6 +9,10 @@ msgctxt "#30101"
 msgid "Site URL"
 msgstr "网址"
 
+msgctxt "#301011"
+msgid "OCR URL"
+msgstr "OCR-API地址"
+
 msgctxt "#30200"
 msgid "Sub preference"
 msgstr "字幕下载偏好"

--- a/resources/lib/sub_provider_service.py
+++ b/resources/lib/sub_provider_service.py
@@ -213,11 +213,13 @@ def handle_params(params):
 def run():
     global agent, logger
 
+    # 获取参数
     params = get_params()
 
     logger = Logger()
     logger.log(sys._getframe().f_code.co_name, "HANDLE PARAMS：%s" % params)
 
+    # 获取url
     zimuku_base_url = __addon__.getSetting("ZiMuKuUrl")
     tpe = __addon__.getSetting("subtype")
     lang = __addon__.getSetting("sublang")
@@ -227,8 +229,11 @@ def run():
                  else __addon__.getSetting("proxy_server"))
         os.environ["HTTP_PROXY"] = os.environ["HTTPS_PROXY"] = proxy
 
+    baiduOcrToken= __addon__.getSetting("assess_token")
+
+    # 查询
     agent = zmkagnt.Zimuku_Agent(zimuku_base_url, __temp__, logger, Unpacker(),
-                                 {'subtype': tpe, 'sublang': lang})
+                                 {'subtype': tpe, 'sublang': lang}, baiduOcrToken)
 
     handle_params(params)
     xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/resources/lib/sub_provider_service.py
+++ b/resources/lib/sub_provider_service.py
@@ -229,11 +229,11 @@ def run():
                  else __addon__.getSetting("proxy_server"))
         os.environ["HTTP_PROXY"] = os.environ["HTTPS_PROXY"] = proxy
 
-    baiduOcrToken= __addon__.getSetting("assess_token")
+    ocrUrl= __addon__.getSetting("ocr_url")
 
     # 查询
     agent = zmkagnt.Zimuku_Agent(zimuku_base_url, __temp__, logger, Unpacker(),
-                                 {'subtype': tpe, 'sublang': lang}, baiduOcrToken)
+                                 {'subtype': tpe, 'sublang': lang}, ocrUrl)
 
     handle_params(params)
     xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/resources/lib/zimuku_agent.py
+++ b/resources/lib/zimuku_agent.py
@@ -17,23 +17,22 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-from ast import expr_context
+
 import os
 import sys
 import time
+import json
+import base64
 import urllib
-
 import requests
 from bs4 import BeautifulSoup
 
 
 class Zimuku_Agent:
-    def __init__(self, base_url, dl_location, logger, unpacker, settings):
+    def __init__(self, base_url, dl_location, logger, unpacker, settings, ocrUrl='https://ddddocr.lm317379829.repl.co/'):
         self.ua = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)'
         self.ZIMUKU_BASE = base_url
-        self.INIT_PAGE = base_url + '/?security_verify_data=313932302c31303830'
         # self.ZIMUKU_API = '%s/search?q=%%s&vertoken=%%s' % base_url
-        self.TOKEN_PARAM = 'security_verify_data=313932302c31303830'
         self.ZIMUKU_API = '%s/search?q=%%s' % base_url
         self.DOWNLOAD_LOCATION = dl_location
         self.FILE_MIN_SIZE = 1024
@@ -43,6 +42,7 @@ class Zimuku_Agent:
         self.plugin_settings = settings
         self.session = requests.Session()
         self.vertoken = ''
+        self.ocrUrl = ocrUrl
 
         # 一次性调用，获取那个vertoken。目测这东西会过期，不过不管那么多了，感觉过两天验证机制又要变
         # self.init_site()
@@ -56,7 +56,6 @@ class Zimuku_Agent:
             'srcurl', '68747470733a2f2f7a696d756b752e6f72672f')
         self.get_page(self.ZIMUKU_BASE)
 
-        self.get_page(self.INIT_PAGE)
         _, resp = self.get_page(self.ZIMUKU_BASE)
         self.get_vertoken(resp)
 
@@ -104,6 +103,53 @@ class Zimuku_Agent:
                             "ERROR READING %s: %s" % (url, e), level=3)
 
         return headers, http_body
+
+    def verify(self, url, append):
+        headers = None
+        http_body = None
+        s = self.session
+        try:
+            request_headers = {'User-Agent': self.ua}
+
+            a = requests.adapters.HTTPAdapter(max_retries=3)
+            s.mount('https://', a)
+
+            self.logger.log(sys._getframe().f_code.co_name, 'requests GET [%s]' % (url), level=3)
+
+            http_response = s.get(url, headers=request_headers)
+
+            if http_response.status_code != 200:
+                soup = BeautifulSoup(http_response.content, 'html.parser')
+                content = soup.find_all(attrs={'class': 'verifyimg'})[0].get('src')
+                if content is not None:
+                    # 处理编码
+                    ocrurl = self.ocrUrl
+                    payload = {'imgdata': content}
+                    headers = {
+                        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.54 Safari/537.36'
+                    }
+                    response = requests.request("POST", ocrurl, headers=headers, json=payload)
+                    result_json = json.loads(response.text)
+                    text = ''
+                    if result_json['code'] == 1:
+                        text = result_json['result']
+                    str1 = ''
+                    i = 0
+                    for ch in text:
+                        if str1 == '':
+                            str1 = hex(ord(text[i]))
+                        else:
+                            str1 += hex(ord(text[i]))
+                        i = i + 1
+
+                    # 使用带验证码的访问
+                    get_cookie_url = '%s%s&%s' % (url, append, 'security_verify_img=' + str1.replace('0x', ''))
+                    http_response = s.get(get_cookie_url, headers=request_headers)
+                    a = 1
+
+        except Exception as e:
+            self.logger.log(sys._getframe().f_code.co_name,
+                            "ERROR READING %s: %s" % (url, e), level=3)
 
     def extract_sub_info(self, sub, lang_info_mode):
         """
@@ -169,7 +215,7 @@ class Zimuku_Agent:
             if rating not in ["0", "1", "2", "3", "4", "5"]:
                 self.logger.log(
                     sys._getframe().f_code.co_name, "NO RATING AVAILABLE IN (%s), URL: %s" %
-                    (rating_div_str, link),
+                                                    (rating_div_str, link),
                     2)
                 rating = "0"
         except:
@@ -200,7 +246,7 @@ class Zimuku_Agent:
         self.logger.log(sys._getframe().f_code.co_name,
                         "Fetching new vertoken form home page")
         try:
-            headers, data = self.get_page(self.ZIMUKU_BASE+'/')
+            headers, data = self.get_page(self.ZIMUKU_BASE + '/')
             hsoup = BeautifulSoup(resp, 'html.parser')
             vertoken = hsoup.find(
                 'input', attrs={'name': 'vertoken'}).attrs.get('value', '')
@@ -233,17 +279,20 @@ class Zimuku_Agent:
 
         # vertoken = self.get_vertoken()
 
-        get_cookie_url = '%s&%s' % (self.ZIMUKU_API %
-                                    (urllib.parse.quote(title)), self.TOKEN_PARAM)
         url = self.ZIMUKU_API % urllib.parse.quote(title)
         try:
             # 10/10/22: 变成搜索要先拿 cookie
-            self.get_page(url)
-            self.get_page(get_cookie_url)
+            # self.get_page(url)
+            # self.get_page(get_cookie_url)
+
+            # 处理验证码逻辑
+            self.verify(url, '&chost=zimuku.org')
 
             # 真正的搜索
             self.logger.log(sys._getframe().f_code.co_name,
                             "Search API url: %s" % (url))
+
+            url += '&chost=zimuku.org'
             _, data = self.get_page(url)
             soup = BeautifulSoup(data, 'html.parser')
         except Exception as e:
@@ -268,8 +317,9 @@ class Zimuku_Agent:
             return self.double_filter(subtitle_list, items)
 
         # 2. 直接找不到，看是否存在同一季的链接，进去找
-        season_name_chn = ('一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二', '十三', '十四', '十五')[
-            int(items['season']) - 1] if s_e != 'N/A' else 'N/A'
+        season_name_chn = \
+            ('一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二', '十三', '十四', '十五')[
+                int(items['season']) - 1] if s_e != 'N/A' else 'N/A'
         season_list = soup.find_all("div", class_="item prel clearfix")
 
         page_list = soup.find('div', class_='pagination')
@@ -451,6 +501,9 @@ class Zimuku_Agent:
         supported_archive_exts = (".zip", ".7z", ".tar", ".bz2", ".rar",
                                   ".gz", ".xz", ".iso", ".tgz", ".tbz2", ".cbr")
         try:
+            # 处理验证码逻辑
+            self.verify(url, '?')
+
             # Subtitle detail page.
             headers, data = self.get_page(url)
             soup = BeautifulSoup(data, 'html.parser')
@@ -458,8 +511,9 @@ class Zimuku_Agent:
 
             if not (url.startswith(('http://', 'https://'))):
                 url = urllib.parse.urljoin(self.ZIMUKU_BASE, url)
-            self.logger.log(sys._getframe().f_code.co_name,
-                            "GET SUB DETAIL PAGE: %s" % (url))
+
+            # 处理验证码逻辑
+            self.verify(url, '?')
 
             # Subtitle download-list page.
             headers, data = self.get_page(url)
@@ -576,6 +630,10 @@ class Zimuku_Agent:
             try:
                 self.logger.log(sys._getframe().f_code.co_name,
                                 "DOWNLOAD SUBTITLE: %s" % (url))
+
+                # 处理验证码逻辑
+                self.verify(url, '?')
+
                 # Download subtitle one by one until success.
                 headers, data = self.get_page(url, Referer=referer)
 
@@ -606,13 +664,13 @@ class Zimuku_Agent:
             else:
                 self.logger.log(
                     sys._getframe().f_code.co_name, 'File received but too small: %s %d bytes' %
-                    (filename, len(data)),
+                                                    (filename, len(data)),
                     level=2)
                 return '', ''
         else:
             self.logger.log(
                 sys._getframe().f_code.co_name, 'Failed to download subtitle from all links: %s' %
-                (referer),
+                                                (referer),
                 level=2)
             return '', ''
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,7 +9,17 @@
 					<control type="edit" format="string">
 						<heading>30101</heading>
 					</control>
-                	<default>http://zimuku.org</default>
+                	<default>https://so.zimuku.org</default>
+                	<constraints>
+                		<allowempty>false</allowempty>
+                	</constraints>
+                </setting>
+				 <setting id="assess_token" type="string" label="301011" help="">
+                	<level>0</level>
+					<control type="edit" format="string">
+						<heading>301011</heading>
+					</control>
+                	<default>https://ddddocr.lm317379829.repl.co/</default>
                 	<constraints>
                 		<allowempty>false</allowempty>
                 	</constraints>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -14,7 +14,7 @@
                 		<allowempty>false</allowempty>
                 	</constraints>
                 </setting>
-				 <setting id="assess_token" type="string" label="301011" help="">
+				 <setting id="ocr_url" type="string" label="301011" help="">
                 	<level>0</level>
 					<control type="edit" format="string">
 						<heading>301011</heading>


### PR DESCRIPTION
「字幕库」加了很多ocr验证，在https://github.com/pizzamx/zimuku_for_kodi/issues/17的基础上修改了一些bug。
ocr服务器换成 https://ddddocr.lm317379829.repl.co 
这个是我在replit上利用ddddocr搭建的免费公益ocr服务器，有能力的可以fork后改成自己的地址。